### PR TITLE
Added folding, removed single tick from pairs

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -17,7 +17,6 @@
         ["[", "]"],
         ["(", ")"],
         ["\"", "\""],
-        ["'", "'"]
     ],
     // symbols that can be used to surround a selection
     "surroundingPairs": [
@@ -25,6 +24,11 @@
         ["[", "]"],
         ["(", ")"],
         ["\"", "\""],
-        ["'", "'"]
-    ]
+    ],
+    "folding": {
+		"markers": {
+			"start": "^\\s*(function|sub|select|for|if|while)\\b",
+			"end": "^\\s*(endfunc|endsub|endselect|next|endif|endwhile)\\b"
+		}
+	}
 }

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -27,8 +27,8 @@
     ],
     "folding": {
 		"markers": {
-			"start": "^\\s*(function|sub|select|for|if|while)\\b",
-			"end": "^\\s*(endfunc|endsub|endselect|next|endif|endwhile)\\b"
+			"start": "^\\s*(?i)(function|sub|select|for|if|while)\\b",
+			"end": "^\\s*(?i)(endfunc|endsub|endselect|next|endif|endwhile)\\b"
 		}
 	}
 }


### PR DESCRIPTION
This PR adds code folding so that you can collapse sections of code in VSCode.

For example, this for loop here:

![image](https://user-images.githubusercontent.com/20888380/144926634-c6518d5b-f2f2-4fdf-b12d-3908dcdd31f7.png)

gets collapsed like this:

![image](https://user-images.githubusercontent.com/20888380/144926680-c5355f15-c43b-4e06-8a43-45254bada2c2.png)

Works on `for` and `while` loops, `functions`, `subroutines`, `select` statements, and `if` statements.

I also removed `'` from `surroundingPairs` and `autoClosingPairs`.  The single tick character is most commonly used for printing variables to a string like this: 

![image](https://user-images.githubusercontent.com/20888380/144927212-dc7e952e-94c6-4662-9aa5-aee13f573131.png)

If the single tick has other functions in the language that does require it to be paired, this can be added back in.  

Likewise, I don't think curly braces are used in *smart*Basic, but I wasn't positive so I left those in.

